### PR TITLE
Improve copy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "README.md"
   ],
   "dependencies": {
+    "mkdirp": "1.0.4",
     "@rollup/plugin-node-resolve": "7.1.1",
     "consola": "2.11.3",
     "cosmiconfig": "6.0.0",
@@ -41,6 +42,7 @@
     "build": "tsc && ncc build src/action.ts -o action"
   },
   "devDependencies": {
+    "@types/mkdirp": "1.0.1",
     "@actions/core": "1.2.3",
     "@types/cross-spawn": "6.0.1",
     "@types/minimatch": "3.0.3",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,7 +6,7 @@ import typescript from "rollup-plugin-typescript2";
 import globby from "globby";
 import pLimit from "p-limit";
 import fs from "fs-extra";
-import { resolve, join, basename, dirname } from "path";
+import { resolve, join, dirname } from "path";
 import { Consola } from "consola";
 import get from "lodash.get";
 import mkdirp from 'mkdirp';

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mkdirp@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
+  integrity sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@13.11.0":
   version "13.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
@@ -590,6 +597,11 @@ minimatch@3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+mkdirp@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
- Now supports glob
- Removes `src/` from output path if it exists in it (to avoid `/dist/src/something` path)
- Runs `mkdirp` before writing the file to avoid issues with copying nested files.