### PR TITLE
fix: exports.require and exports.default should be prefixed with "./"

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -367,8 +367,8 @@ export function validatePackageJson(pkg: any) {
   expect("typescript.definition", `${distDir}/index.d.ts`);
 
   if (pkg.exports) {
-    expect("exports.require", pkg.main);
-    expect("exports.default", `${distDir}/index.mjs`);
+    expect("exports.require",  `./${pkg.main}`);
+    expect("exports.default", `./${distDir}/index.mjs`);
   }
 }
 


### PR DESCRIPTION
See https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json