### PR TITLE
Disable sourcemaps

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -126,7 +126,7 @@ async function buildSingle({ distDir, distPath = '' }: { distDir: string; distPa
 
   const commonOutputOptions = {
     preferConst: true,
-    sourcemap: true,
+    sourcemap: false,
   };
 
   const generates = [
@@ -211,7 +211,7 @@ async function build(
 
   const commonOutputOptions = {
     preferConst: true,
-    sourcemap: true,
+    sourcemap: false,
   };
 
   const generates = [


### PR DESCRIPTION
Sourcemaps are misleading and actually they are not necessary