### PR TITLE
feat: remove the flag for building a single package

### DIFF
--- a/.changeset/tasty-bags-thank.md
+++ b/.changeset/tasty-bags-thank.md
@@ -1,0 +1,5 @@
+---
+"bob-the-bundler": minor
+---
+
+remove the `--single` flag. The value is now derived from the `package.json` `workspaces` property. If your workspace is configured properly this is not a breaking change.

--- a/test/__fixtures__/simple-monorepo/package.json
+++ b/test/__fixtures__/simple-monorepo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "monorepo",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/test/__fixtures__/simple-monorepo/packages/a/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/a/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "a",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  }
+}

--- a/test/__fixtures__/simple-monorepo/packages/a/src/index.ts
+++ b/test/__fixtures__/simple-monorepo/packages/a/src/index.ts
@@ -1,0 +1,1 @@
+export const a = "WUP";

--- a/test/__fixtures__/simple-monorepo/packages/b/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "b",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  }
+}

--- a/test/__fixtures__/simple-monorepo/packages/b/src/index.ts
+++ b/test/__fixtures__/simple-monorepo/packages/b/src/index.ts
@@ -1,0 +1,1 @@
+export const b = "SUP";

--- a/test/__fixtures__/simple-monorepo/tsconfig.json
+++ b/test/__fixtures__/simple-monorepo/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "target": "es2018",
+    "lib": ["es6", "esnext", "es2015", "dom", "webworker"],
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "declaration": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "paths": {},
+    "jsx": "preserve",
+    "sourceMap": false,
+    "inlineSourceMap": false
+  },
+  "include": ["packages"],
+  "exclude": ["**/dist", "**/temp"]
+}

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -8,27 +8,13 @@ const binaryFolder = path.join(__dirname, "..", "dist", "index.js");
 it("can bundle a simple project", async () => {
   await fse.remove(path.resolve(fixturesFolder, "simple", "dist"));
   const result = await execa("node", [binaryFolder, "build"], {
-    cwd: path.resolve(fixturesFolder, "simple"),
+    cwd: path.resolve(fixturesFolder, "simple")
   });
   expect(result.exitCode).toEqual(0);
-  const indexJsFilePath = path.resolve(
-    fixturesFolder,
-    "simple",
-    "dist",
-    "index.js"
-  );
-  const indexMjsFilePath = path.resolve(
-    fixturesFolder,
-    "simple",
-    "dist",
-    "index.js"
-  );
-  const packageJsonFilePath = path.resolve(
-    fixturesFolder,
-    "simple",
-    "dist",
-    "package.json"
-  );
+  const baseDistPath = path.resolve(fixturesFolder, "simple", "dist");
+  const indexJsFilePath = path.resolve(baseDistPath, "index.js");
+  const indexMjsFilePath = path.resolve(baseDistPath, "index.mjs");
+  const packageJsonFilePath = path.resolve(baseDistPath, "package.json");
 
   expect(fse.readFileSync(indexJsFilePath, "utf8")).toMatchInlineSnapshot(`
     "'use strict';
@@ -41,18 +27,138 @@ it("can bundle a simple project", async () => {
     "
   `);
   expect(fse.readFileSync(indexMjsFilePath, "utf8")).toMatchInlineSnapshot(`
-    "'use strict';
+    "var someNumber = 1;
 
-    Object.defineProperty(exports, '__esModule', { value: true });
-
-    var someNumber = 1;
-
-    exports.someNumber = someNumber;
+    export { someNumber };
     "
   `);
   expect(fse.readFileSync(packageJsonFilePath, "utf8")).toMatchInlineSnapshot(`
     "{
       \\"name\\": \\"simple\\",
+      \\"main\\": \\"index.js\\",
+      \\"module\\": \\"index.mjs\\",
+      \\"typings\\": \\"index.d.ts\\",
+      \\"typescript\\": {
+        \\"definition\\": \\"index.d.ts\\"
+      },
+      \\"exports\\": {
+        \\".\\": {
+          \\"require\\": \\"./index.js\\",
+          \\"import\\": \\"./index.mjs\\"
+        },
+        \\"./*\\": {
+          \\"require\\": \\"./*.js\\",
+          \\"import\\": \\"./*.mjs\\"
+        },
+        \\"./package.json\\": \\"./package.json\\"
+      }
+    }
+    "
+  `);
+});
+
+it("can build a monorepo project", async () => {
+  await fse.remove(
+    path.resolve(fixturesFolder, "simple-monorepo", "a", "dist")
+  );
+  await fse.remove(
+    path.resolve(fixturesFolder, "simple-monorepo", "b", "dist")
+  );
+  await execa("tsc", {
+    cwd: path.resolve(fixturesFolder, "simple-monorepo")
+  });
+  const result = await execa("node", [binaryFolder, "build"], {
+    cwd: path.resolve(fixturesFolder, "simple-monorepo")
+  });
+  expect(result.exitCode).toEqual(0);
+  const baseDistAPath = path.resolve(
+    fixturesFolder,
+    "simple-monorepo",
+    "packages",
+    "a",
+    "dist"
+  );
+  const baseDistBPath = path.resolve(
+    fixturesFolder,
+    "simple-monorepo",
+    "packages",
+    "b",
+    "dist"
+  );
+  const files = {
+    a: {
+      "index.js": path.resolve(baseDistAPath, "index.js"),
+      "index.mjs": path.resolve(baseDistAPath, "index.mjs"),
+      "package.json": path.resolve(baseDistAPath, "package.json")
+    },
+    b: {
+      "index.js": path.resolve(baseDistBPath, "index.js"),
+      "index.mjs": path.resolve(baseDistBPath, "index.mjs"),
+      "package.json": path.resolve(baseDistBPath, "package.json")
+    }
+  };
+
+  expect(fse.readFileSync(files.a["index.js"], "utf8")).toMatchInlineSnapshot(`
+    "'use strict';
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+    const a = \\"WUP\\";
+
+    exports.a = a;
+    "
+  `);
+  expect(fse.readFileSync(files.a["index.mjs"], "utf8")).toMatchInlineSnapshot(`
+    "const a = \\"WUP\\";
+
+    export { a };
+    "
+  `);
+  expect(fse.readFileSync(files.a["package.json"], "utf8"))
+    .toMatchInlineSnapshot(`
+    "{
+      \\"name\\": \\"a\\",
+      \\"main\\": \\"index.js\\",
+      \\"module\\": \\"index.mjs\\",
+      \\"typings\\": \\"index.d.ts\\",
+      \\"typescript\\": {
+        \\"definition\\": \\"index.d.ts\\"
+      },
+      \\"exports\\": {
+        \\".\\": {
+          \\"require\\": \\"./index.js\\",
+          \\"import\\": \\"./index.mjs\\"
+        },
+        \\"./*\\": {
+          \\"require\\": \\"./*.js\\",
+          \\"import\\": \\"./*.mjs\\"
+        },
+        \\"./package.json\\": \\"./package.json\\"
+      }
+    }
+    "
+  `);
+
+  expect(fse.readFileSync(files.b["index.js"], "utf8")).toMatchInlineSnapshot(`
+    "'use strict';
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+    const b = \\"SUP\\";
+
+    exports.b = b;
+    "
+  `);
+  expect(fse.readFileSync(files.b["index.mjs"], "utf8")).toMatchInlineSnapshot(`
+    "const b = \\"SUP\\";
+
+    export { b };
+    "
+  `);
+  expect(fse.readFileSync(files.b["package.json"], "utf8"))
+    .toMatchInlineSnapshot(`
+    "{
+      \\"name\\": \\"b\\",
       \\"main\\": \\"index.js\\",
       \\"module\\": \\"index.mjs\\",
       \\"typings\\": \\"index.d.ts\\",

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -7,8 +7,8 @@ const binaryFolder = path.join(__dirname, "..", "dist", "index.js");
 
 it("can bundle a simple project", async () => {
   await fse.remove(path.resolve(fixturesFolder, "simple", "dist"));
-  const result = await execa("node", [binaryFolder, "build", "--single"], {
-    cwd: path.resolve(fixturesFolder, "simple")
+  const result = await execa("node", [binaryFolder, "build"], {
+    cwd: path.resolve(fixturesFolder, "simple"),
   });
   expect(result.exitCode).toEqual(0);
   const indexJsFilePath = path.resolve(


### PR DESCRIPTION
Derive the flag value from the package.json by looking at the `workspaces` property. Also adds an integration test for a monorepository.


____

Closes https://github.com/kamilkisiela/bob/issues/50