### PR TITLE
feat: config refactor

### DIFF
--- a/.changeset/ten-panthers-play.md
+++ b/.changeset/ten-panthers-play.md
@@ -1,0 +1,30 @@
+---
+"bob-the-bundler": major
+---
+
+Remove the global config. Please add `bob: false` to the individual `package.json` workspaces that should not be processed by bob.
+
+This is the new config format for bob.
+
+````ts
+type BobConfig =
+  /** completely disable bob for this package. */
+  | false
+  | {
+      /** Whether the package should be built. */
+      build?:
+        | false
+        | {
+            /** Files to copy from the package root to dist */
+            copy?: Array<string>;
+          };
+      /** Whether the package should be checked. */
+      check?:
+        | false
+        | {
+            /** Exports within the package that should not be checked. */
+            skip?: Array<string>;
+          };
+    };
+    ```
+````

--- a/.changeset/ten-panthers-play.md
+++ b/.changeset/ten-panthers-play.md
@@ -6,7 +6,7 @@ Remove the global config. Please add `bob: false` to the individual `package.jso
 
 This is the new config format for bob.
 
-````ts
+```ts
 type BobConfig =
   /** completely disable bob for this package. */
   | false
@@ -26,5 +26,4 @@ type BobConfig =
             skip?: Array<string>;
           };
     };
-    ```
-````
+```

--- a/README.md
+++ b/README.md
@@ -1,85 +1,67 @@
-# Bob (The Bundler)
+# Bob (The ~~Bundler~~ Butler)
 
-There's no documentation yet but you can check [GraphQL Code Generator](https://github.com/dotansimha/graphql-code-generator) repository to see how to use Bob.
+Bob is the TypeScript build, bundle and verification tool used by almost all [The Guild](https://the-guild.dev) open source projects.
+
+Scope:
+
+- **Build**: Build ESM and CommonJS compatible npm packages
+- **Verify**: Ensure all ESM and CommonJS imports within a npm package are usable
+- **Bundle**: Build a single executable for an application (experimental)
 
 ## Requirements
 
-- Supports only scoped packages (same scope)
-- Yarn Workspaces
-- TypeScript with Paths
+- Yarn workspace or single package project
+- TypeScript
 - It's so strict you shouldn't use it!
+
+## Setup
+
+Setting up bob is currently undocumented. You can check [GraphQL Code Generator](https://github.com/dotansimha/graphql-code-generator) repository (or any other The Guild repository).
 
 ## Configuration
 
-Bob only accepts `bob.config.js` in root directory:
+You can add a `bob` key to each `package.json`.
+
+**Disable bob for a single package**
 
 ```js
-module.exports = {
-  scope: "@graphql-codegen", // Scope of organization
-  ignore: ["@graphql-codegen/website", "@graphql-codegen/live-demo"], // ignored packages
-  track: [
-    // files in root that mark the entire workspace as dirty
-    "bob.config.js", // we could include it in Bob itself but we decided to turn your life into hell :)
-    "jest.config.js",
-    "jest-project.js",
-    "package.json",
-    "tsconfig.json",
-    // files in packages that mark the package as dirty
-    "<project>/src/**",
-    "<project>/jest.config.js",
-    "<project>/package.json",
-    "<project>/tsconfig.json",
-  ],
-  base: "origin/master", // we need to compare against something
-  commands: {
-    test: {
-      track: ["<project>/tests/**"],
-      run(affected) {
-        // {
-        //   paths: string[] <- ['packages/core', 'packages/cli']
-        //   names: string[] <- ['@foo/core', '@foo/cli']
-        // }
-
-        // why such a weird syntax? We use spawn, so you have too
-        return [`yarn`, ["test", ...affected.paths]];
-      },
-    },
-    build: {
-      run() {
-        return [`yarn`, ["build"]];
-      },
-    },
-  },
-};
+{
+  "name": "graphql-lfg",
+  "bob": false // exclude a single package from all things bob related
+}
 ```
 
-## Build Options
+**Disable build for a single package**
 
-In your `<project>/package.json`:
-
-```json
+```js
 {
-  "buildOptions": {
-    "external": ["simple-git/promise"], // Marks nested imports as external
-    "bin": {
-      "cli": {
-        "input": "src/cli.ts" // Entry point for `cli` command
-      }
-    }
+  "name": "graphql-lfg",
+  "bob": {
+    "build": false
   }
 }
 ```
 
-## Support for Node ES Modules
+**Disable check for a single package**
 
-In your `<project>/package.json`, just add `"exports"` like this:
-
-```json
+```js
 {
-  "main": "dist/index.cjs.js",
-  "exports": {
-    "require": "dist/index.cjs.js", // should match "main"
-    "default": "dist/index.mjs" // should ends with ".mjs" extension
+  "name": "graphql-lfg",
+  "bob": {
+    "check": false
+  }
+}
+```
+
+**Disable check for a single export in a package**
+
+```js
+{
+  "name": "graphql-lfg",
+  "bob": {
+    "check": {
+      "skip": ["./foo"]
+    }
   }
 }
 ```
@@ -88,12 +70,10 @@ In your `<project>/package.json`, just add `"exports"` like this:
 
 ```bash
 
-$ bob affected test
-$ bob affected build
-
 $ bob build
-$ bob prepack
+$ bob check
 
+# only use this command if you know the secret sauce
 $ bob runify
 
 ```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@vercel/ncc": "^0.34.0",
     "builtins": "^5.0.1",
     "consola": "^2.15.3",
-    "cosmiconfig": "^7.0.1",
     "cross-spawn": "^7.0.3",
     "dependency-graph": "^0.11.0",
     "fs-extra": "^10.1.0",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,11 +1,9 @@
 import { CommandModule } from "yargs";
-import { BobConfig } from "./config";
 import { Consola } from "consola";
 
 export { CommandModule as Command };
 
 export interface CommandAPI {
-  config: BobConfig;
   reporter: Consola;
 }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -84,7 +84,7 @@ export const checkCommand = createCommand<{}, {}>((api) => {
         const distPackageJSON = await fse.readJSON(distPackageJSONPath);
 
         try {
-          checkExportsMapIntegrity({
+          await checkExportsMapIntegrity({
             cwd: path.join(cwd, "dist"),
             packageJSON: distPackageJSON,
             skipExports: new Set<string>(config?.check?.skip ?? []),

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -57,7 +57,6 @@ export const checkCommand = createCommand<{}, {}>((api) => {
       } else {
         const workspacesPaths = await getWorkspacePackagePaths(cwd, workspaces);
         const limit = pLimit(20);
-
         await Promise.all(
           workspacesPaths.map((workspacePath) =>
             limit(async () => {
@@ -66,7 +65,7 @@ export const checkCommand = createCommand<{}, {}>((api) => {
                 packageJSONPath
               );
               checkConfigs.push({
-                cwd,
+                cwd: workspacePath,
                 packageJSON,
               });
             })

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -75,6 +75,7 @@ export const checkCommand = createCommand<{}, {}>((api) => {
 
       const limit = pLimit(20);
 
+      let didFail = false;
       await Promise.allSettled(
         checkConfigs.map(({ cwd, packageJSON }) =>
           limit(async () => {
@@ -97,13 +98,17 @@ export const checkCommand = createCommand<{}, {}>((api) => {
               api.reporter.error(
                 `Integrity check of '${packageJSON.name}' failed.`
               );
-
-              throw err;
+              api.reporter.log(err);
+              didFail = true;
+              return;
             }
             api.reporter.success(`Checked integrity of '${packageJSON.name}'.`);
           })
         )
       );
+      if (didFail) {
+        throw new Error("One ore more integrity checks failed.");
+      }
     },
   };
 });

--- a/src/commands/runify.ts
+++ b/src/commands/runify.ts
@@ -10,7 +10,6 @@ import { build as tsup } from "tsup";
 import { spawn } from "child_process";
 
 import { createCommand } from "../command";
-import { BobConfig } from "../config";
 
 export const distDir = "dist";
 
@@ -29,7 +28,7 @@ export const runifyCommand = createCommand<
     tag?: string[];
   }
 >((api) => {
-  const { config, reporter } = api;
+  const { reporter } = api;
 
   return {
     command: "runify",
@@ -55,7 +54,7 @@ export const runifyCommand = createCommand<
         Array.isArray(rootPackageJSON.workspaces) === false;
 
       if (isSinglePackage) {
-        return runify(join(process.cwd(), "package.json"), config, reporter);
+        return runify(join(process.cwd(), "package.json"), reporter);
       }
 
       const limit = pLimit(1);
@@ -101,20 +100,14 @@ export const runifyCommand = createCommand<
             }
           }
 
-          return limit(() =>
-            runify(depGraph.getNodeData(name).path, config, reporter)
-          );
+          return limit(() => runify(depGraph.getNodeData(name).path, reporter));
         })
       );
     },
   };
 });
 
-async function runify(
-  packagePath: string,
-  _config: BobConfig,
-  reporter: Consola
-) {
+async function runify(packagePath: string, reporter: Consola) {
   const cwd = packagePath.replace("/package.json", "");
   const pkg = await readPackageJson(cwd);
   const buildOptions: BuildOptions = pkg.buildOptions || {};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const buildArtifactDirectories = [`**/dist/**`, `**/build/**`] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import yargs, { Argv } from "yargs";
 import consola from "consola";
-import { useConfig } from "./config";
 import { CommandFactory } from "./command";
 import { buildCommand } from "./commands/build";
 import { runifyCommand } from "./commands/runify";
@@ -9,8 +8,6 @@ import { bootstrapCommand } from "./commands/bootstrap";
 import { checkCommand } from "./commands/check";
 
 async function main() {
-  const config = await useConfig();
-
   const root: Argv = yargs
     .scriptName("bob")
     .detectLocale(false)
@@ -26,7 +23,7 @@ async function main() {
   const reporter = consola.create({});
 
   commands
-    .reduce((cli, cmd) => cli.command(cmd({ config, reporter })), root)
+    .reduce((cli, cmd) => cli.command(cmd({ reporter })), root)
     .help()
     .showHelpOnFail(false).argv;
 }

--- a/src/utils/get-root-package-json.ts
+++ b/src/utils/get-root-package-json.ts
@@ -1,0 +1,19 @@
+import globby from "globby";
+import * as fse from "fs-extra";
+
+export async function getRootPackageJSON(cwd: string) {
+  const [rootPackageJSONPath] = await globby("package.json", {
+    cwd,
+    absolute: true,
+  });
+
+  if (rootPackageJSONPath === undefined) {
+    throw new Error("Must be executed within a (monorepo-)package root.");
+  }
+
+  const rootPackageJSON: Record<string, unknown> = await fse.readJSON(
+    rootPackageJSONPath
+  );
+
+  return rootPackageJSON;
+}

--- a/src/utils/get-workspace-package-paths.ts
+++ b/src/utils/get-workspace-package-paths.ts
@@ -1,0 +1,24 @@
+import globby from "globby";
+import path from "path";
+
+import { buildArtifactDirectories } from "../constants";
+
+export async function getWorkspacePackagePaths(
+  cwd: string,
+  workspaces: Array<string>
+) {
+  const packageJSONPaths = await globby(
+    workspaces.map((workspacePattern) =>
+      path.join(workspacePattern, "package.json")
+    ),
+    {
+      cwd,
+      absolute: true,
+      ignore: ["**/node_modules/**", ...buildArtifactDirectories],
+    }
+  );
+
+  return packageJSONPaths.map((packageJSONPath) =>
+    path.dirname(packageJSONPath)
+  );
+}

--- a/src/utils/get-workspace-package-paths.ts
+++ b/src/utils/get-workspace-package-paths.ts
@@ -8,12 +8,12 @@ export async function getWorkspacePackagePaths(
   workspaces: Array<string>
 ) {
   const packageJSONPaths = await globby(
-    workspaces.map((workspacePattern) =>
-      path.join(workspacePattern, "package.json")
-    ),
+    workspaces
+      /** We are only interested in workspaces that are packages (for now.) */
+      .filter((workspacePattern) => workspacePattern.startsWith("packages/"))
+      .map((workspacePattern) => path.join(workspacePattern, "package.json")),
     {
       cwd,
-      absolute: true,
       ignore: ["**/node_modules/**", ...buildArtifactDirectories],
     }
   );

--- a/src/utils/get-workspaces.ts
+++ b/src/utils/get-workspaces.ts
@@ -1,0 +1,28 @@
+import zod from "zod";
+
+const WorkspaceModel = zod.optional(
+  zod.union([
+    zod.array(zod.string()),
+    zod.object({
+      packages: zod.optional(zod.array(zod.string())),
+      nohoist: zod.optional(zod.array(zod.string())),
+    }),
+  ])
+);
+
+export function getWorkspaces(
+  packageJSON: Record<string, unknown>
+): Array<string> | null {
+  const result = WorkspaceModel.parse(packageJSON.workspaces);
+  if (result == null) {
+    return null;
+  }
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (Array.isArray(result?.packages)) {
+    return result.packages;
+  }
+
+  return null;
+}

--- a/test/__fixtures__/simple/package.json
+++ b/test/__fixtures__/simple/package.json
@@ -42,9 +42,16 @@
     "access": "public"
   },
   "type": "module",
-  "buildOptions": {
-    "copy": [
-      "foo.json"
-    ]
+  "bob": {
+    "build": {
+      "copy": [
+        "foo.json"
+      ]
+    },
+    "check": {
+      "skip": [
+        "./file-that-throws"
+      ]
+    }
   }
 }

--- a/test/__fixtures__/simple/src/file-that-throws.ts
+++ b/test/__fixtures__/simple/src/file-that-throws.ts
@@ -1,0 +1,1 @@
+throw new Error("KEK");


### PR DESCRIPTION
Remove the global config. Please add `bob: false` to the individual `package.json` workspaces that should not be processed by bob.

This is the new config format for bob.

```ts
type BobConfig =
  /** completely disable bob for this package. */
  | false
  | {
      /** Whether the package should be built. */
      build?:
        | false
        | {
            /** Files to copy from the package root to dist */
            copy?: Array<string>;
          };
      /** Whether the package should be checked. */
      check?:
        | false
        | {
            /** Exports within the package that should not be checked. */
            skip?: Array<string>;
          };
    };
```

______

Closes https://github.com/kamilkisiela/bob/issues/79
Closes https://github.com/kamilkisiela/bob/issues/77