### PR TITLE
fix: race conditions of tsc

### DIFF
--- a/.changeset/seven-berries-appear.md
+++ b/.changeset/seven-berries-appear.md
@@ -1,0 +1,5 @@
+---
+"bob-the-bundler": patch
+---
+
+Run typescript tsc commands in sequence instead of in parallel to avoid race conditions where the `.bob/cjs` or `.bob/esm` folder is missing.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -64,29 +64,32 @@ function compilerOptionsToArgs(
   return args;
 }
 
+function assertTypeScriptBuildResult(result: execa.ExecaReturnValue<string>) {
+  if (result.exitCode !== 0) {
+    console.log("TypeScript compiler exited with non-zero exit code.");
+    console.log(result.stdout);
+    throw new Error("TypeScript compiler exited with non-zero exit code.");
+  }
+}
+
 async function buildTypeScript(buildPath: string) {
-  const results = await Promise.all([
-    execa("npx", [
+  assertTypeScriptBuildResult(
+    await execa("npx", [
       "tsc",
       ...compilerOptionsToArgs(typeScriptCompilerOptions("esm")),
       "--outDir",
       join(buildPath, "esm"),
-    ]),
-    execa("npx", [
+    ])
+  );
+
+  assertTypeScriptBuildResult(
+    await execa("npx", [
       "tsc",
       ...compilerOptionsToArgs(typeScriptCompilerOptions("cjs")),
       "--outDir",
       join(buildPath, "cjs"),
-    ]),
-  ]);
-
-  for (const result of results) {
-    if (result.exitCode !== 0) {
-      console.log("TypeScript compiler exited with non-zero exit code.");
-      console.log(result.stdout);
-      throw new Error("TypeScript compiler exited with non-zero exit code.");
-    }
-  }
+    ])
+  );
 }
 
 export const buildCommand = createCommand<{}, {}>((api) => {


### PR DESCRIPTION
Yoga builds started failing.

After [a few wrong assumptions](https://github.com/dotansimha/graphql-yoga/pull/1407), I figured out that bob did not create the `.bob/cjs` folder sometimes when running `bob build`. After I moved the `tsc` calls in sequence both folders were there consistently.