### PR TITLE
feat: build specific package(s) in monorepos

### DIFF
--- a/.changeset/proud-pens-enjoy.md
+++ b/.changeset/proud-pens-enjoy.md
@@ -1,0 +1,5 @@
+---
+"bob-the-bundler": minor
+---
+
+build specific package(s) in monorepos

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -94,7 +94,12 @@ async function buildTypeScript(buildPath: string) {
   );
 }
 
-export const buildCommand = createCommand<{}, { pkgs?: string[] }>((api) => {
+export const buildCommand = createCommand<
+  {},
+  {
+    pkgs?: string[];
+  }
+>((api) => {
   const { reporter } = api;
 
   return {


### PR DESCRIPTION
Running `yarn build @graphql-tools/url-loader` in [`graphql-tools`](https://github.com/ardatan/graphql-tools) would build only [the `@graphql-tools/url-loader` package in `packages/loaders/url`](https://github.com/ardatan/graphql-tools/tree/master/packages/loaders/url).

Furthermore, running `yarn build @graphql-tools/url-loader @graphql-tools/utils` would build only [`@graphql-tools/url-loader`](https://github.com/ardatan/graphql-tools/tree/master/packages/loaders/url) and  [`@graphql-tools/utils`](https://github.com/ardatan/graphql-tools/tree/master/packages/utils).

Do note that the build step won't have a big performance gain due to `tsc` (which still has to check the whole project). Since monorepos often reference other packages within, isolated `tsc` builds seem to not be possible.