### PR TITLE
feat: ability to re-write default tsconfig

### DIFF
--- a/.changeset/gentle-radios-visit.md
+++ b/.changeset/gentle-radios-visit.md
@@ -1,0 +1,5 @@
+---
+"bob-the-bundler": minor
+---
+
+ability to rewrite default tsconfig.json file


### PR DESCRIPTION
I have a client, server, and infrastructure in one monorepo. For all of them, I use different `tsconfig.json` files. So this option is really helpful instead of using static `tsconfig.json` from the root.

Please, let me know if this is useless and if you don't want this feature. 

Thanks!