### PR TITLE
Copy files under src to destination by module type

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -489,13 +489,11 @@ async function copyToDist(cwd: string, files: string[], distDir: string) {
           }
 
           // FOr each type, copy files to the relevant directory
-          const allTypesExec: Array<Promise<void>> = [];
-          allTypes.forEach(type => {
-            allTypesExec.push(
-              executeCopy(sourcePath, join(distDir, file.replace('src/', `${type}/`))),
-            );
-          });
-          await Promise.all(allTypesExec);
+await Promise.all(
+  allTypes.map(type =>
+    executeCopy(sourcePath, join(distDir, file.replace('src/', `${type}/`)))
+  )
+)
         } else {
           const destPath = join(distDir, file);
           executeCopy(sourcePath, destPath);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -489,11 +489,11 @@ async function copyToDist(cwd: string, files: string[], distDir: string) {
           }
 
           // FOr each type, copy files to the relevant directory
-await Promise.all(
-  allTypes.map(type =>
-    executeCopy(sourcePath, join(distDir, file.replace('src/', `${type}/`)))
-  )
-)
+          await Promise.all(
+            allTypes.map(type =>
+              executeCopy(sourcePath, join(distDir, file.replace('src/', `${type}/`))),
+            ),
+          );
         } else {
           const destPath = join(distDir, file);
           executeCopy(sourcePath, destPath);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -466,6 +466,11 @@ export function validatePackageJson(
   }
 }
 
+async function executeCopy(sourcePath: string, destPath: string) {
+  await mkdirp(dirname(destPath));
+  await fse.copyFile(sourcePath, destPath);
+}
+
 async function copyToDist(cwd: string, files: string[], distDir: string) {
   const allFiles = await globby(files, { cwd });
 
@@ -473,9 +478,16 @@ async function copyToDist(cwd: string, files: string[], distDir: string) {
     allFiles.map(async file => {
       if (await fse.pathExists(join(cwd, file))) {
         const sourcePath = join(cwd, file);
-        const destPath = join(distDir, file.replace('src/', ''));
-        await mkdirp(dirname(destPath));
-        await fse.copyFile(sourcePath, destPath);
+        if (file.includes('src/')) {
+          const allTypes: Array<Promise<void>> = [];
+          ['esm', 'cjs'].forEach(type => {
+            allTypes.push(executeCopy(sourcePath, join(distDir, file.replace('src/', `${type}/`))));
+          });
+          await Promise.all(allTypes);
+        } else {
+          const destPath = join(distDir, file);
+          executeCopy(sourcePath, destPath);
+        }
       }
     }),
   );

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -480,7 +480,7 @@ async function copyToDist(cwd: string, files: string[], distDir: string) {
         const sourcePath = join(cwd, file);
         if (file.includes('src/')) {
           // Figure relevant module types
-          const allTypes: string[] = [];
+          const allTypes: ('cjs' | 'esm')[] = [];
           if (await fse.pathExists(join(distDir, 'esm'))) {
             allTypes.push('esm');
           }

--- a/test/__fixtures__/simple/package.json
+++ b/test/__fixtures__/simple/package.json
@@ -32,8 +32,7 @@
         "default": "./dist/esm/*.js"
       }
     },
-    "./package.json": "./package.json",
-    "./style.css": "./style.css"
+    "./package.json": "./package.json"
   },
   "typings": "dist/typings/index.d.ts",
   "publishConfig": {

--- a/test/__fixtures__/simple/package.json
+++ b/test/__fixtures__/simple/package.json
@@ -32,7 +32,8 @@
         "default": "./dist/esm/*.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./style.css": "./dist/esm/style.css"
   },
   "typings": "dist/typings/index.d.ts",
   "publishConfig": {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -77,7 +77,8 @@ it('can bundle a simple project', async () => {
             "default": "./esm/*.js"
           }
         },
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+        "./style.css": "./esm/style.css"
       }
     }
   `);

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -77,8 +77,7 @@ it('can bundle a simple project', async () => {
             "default": "./esm/*.js"
           }
         },
-        "./package.json": "./package.json",
-        "./style.css": "./style.css"
+        "./package.json": "./package.json"
       }
     }
   `);


### PR DESCRIPTION
Makes root files be copied to dist, and ./src files copied to esm/cjs/both