### PR TITLE
Custom tsconfig path for the build command

### DIFF
--- a/.changeset/proud-hairs-promise.md
+++ b/.changeset/proud-hairs-promise.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': minor
+---
+
+Custom tsconfig path for the build command

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -68,12 +68,12 @@ function assertTypeScriptBuildResult(result: ExecaReturnValue) {
 
 async function buildTypeScript(
   buildPath: string,
-  options: { tsconfigPath?: string; incremental?: boolean } = {},
+  options: { tsconfig?: string; incremental?: boolean } = {},
 ) {
   assertTypeScriptBuildResult(
     await execa('npx', [
       'tsc',
-      ...(options.tsconfigPath ? ['--project', options.tsconfigPath] : []),
+      ...(options.tsconfig ? ['--project', options.tsconfig] : []),
       ...compilerOptionsToArgs(typeScriptCompilerOptions('esm')),
       ...(options.incremental ? ['--incremental'] : []),
       '--outDir',
@@ -84,7 +84,7 @@ async function buildTypeScript(
   assertTypeScriptBuildResult(
     await execa('npx', [
       'tsc',
-      ...(options.tsconfigPath ? ['--project', options.tsconfigPath] : []),
+      ...(options.tsconfig ? ['--project', options.tsconfig] : []),
       ...compilerOptionsToArgs(typeScriptCompilerOptions('cjs')),
       ...(options.incremental ? ['--incremental'] : []),
       '--outDir',
@@ -96,7 +96,7 @@ async function buildTypeScript(
 export const buildCommand = createCommand<
   {},
   {
-    tsconfigPath?: string;
+    tsconfig?: string;
     incremental?: boolean;
   }
 >(api => {
@@ -107,7 +107,7 @@ export const buildCommand = createCommand<
     describe: 'Build',
     builder(yargs) {
       return yargs.options({
-        tsconfigPath: {
+        tsconfig: {
           describe: 'Which tsconfig file to use when building TypeScript.',
           type: 'string',
         },
@@ -117,7 +117,7 @@ export const buildCommand = createCommand<
         },
       });
     },
-    async handler({ tsconfigPath, incremental }) {
+    async handler({ tsconfig, incremental }) {
       const cwd = process.cwd();
       const rootPackageJSON = await getRootPackageJSON();
       const workspaces = await getWorkspaces(rootPackageJSON);
@@ -129,7 +129,7 @@ export const buildCommand = createCommand<
         if (!incremental) {
           await fse.remove(buildPath);
         }
-        await buildTypeScript(buildPath, { tsconfigPath, incremental });
+        await buildTypeScript(buildPath, { tsconfig, incremental });
         const pkg = await fse.readJSON(resolve(cwd, 'package.json'));
         const fullName: string = pkg.name;
 
@@ -166,7 +166,7 @@ export const buildCommand = createCommand<
       if (!incremental) {
         await fse.remove(bobBuildPath);
       }
-      await buildTypeScript(bobBuildPath, { tsconfigPath, incremental });
+      await buildTypeScript(bobBuildPath, { tsconfig, incremental });
 
       await Promise.all(
         packageInfoList.map(({ cwd, pkg, fullName }) =>

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -66,10 +66,14 @@ function assertTypeScriptBuildResult(result: ExecaReturnValue) {
   }
 }
 
-async function buildTypeScript(buildPath: string, options: { incremental?: boolean } = {}) {
+async function buildTypeScript(
+  buildPath: string,
+  options: { tsconfigPath?: string; incremental?: boolean } = {},
+) {
   assertTypeScriptBuildResult(
     await execa('npx', [
       'tsc',
+      ...(options.tsconfigPath ? ['--project', options.tsconfigPath] : []),
       ...compilerOptionsToArgs(typeScriptCompilerOptions('esm')),
       ...(options.incremental ? ['--incremental'] : []),
       '--outDir',
@@ -80,6 +84,7 @@ async function buildTypeScript(buildPath: string, options: { incremental?: boole
   assertTypeScriptBuildResult(
     await execa('npx', [
       'tsc',
+      ...(options.tsconfigPath ? ['--project', options.tsconfigPath] : []),
       ...compilerOptionsToArgs(typeScriptCompilerOptions('cjs')),
       ...(options.incremental ? ['--incremental'] : []),
       '--outDir',
@@ -91,6 +96,7 @@ async function buildTypeScript(buildPath: string, options: { incremental?: boole
 export const buildCommand = createCommand<
   {},
   {
+    tsconfigPath?: string;
     incremental?: boolean;
   }
 >(api => {
@@ -101,13 +107,17 @@ export const buildCommand = createCommand<
     describe: 'Build',
     builder(yargs) {
       return yargs.options({
+        tsconfigPath: {
+          describe: 'Which tsconfig file to use when building TypeScript.',
+          type: 'string',
+        },
         incremental: {
           describe: 'Better performance by building only packages that had changes.',
           type: 'boolean',
         },
       });
     },
-    async handler({ incremental }) {
+    async handler({ tsconfigPath, incremental }) {
       const cwd = process.cwd();
       const rootPackageJSON = await getRootPackageJSON();
       const workspaces = await getWorkspaces(rootPackageJSON);
@@ -119,7 +129,7 @@ export const buildCommand = createCommand<
         if (!incremental) {
           await fse.remove(buildPath);
         }
-        await buildTypeScript(buildPath, { incremental });
+        await buildTypeScript(buildPath, { tsconfigPath, incremental });
         const pkg = await fse.readJSON(resolve(cwd, 'package.json'));
         const fullName: string = pkg.name;
 
@@ -156,7 +166,7 @@ export const buildCommand = createCommand<
       if (!incremental) {
         await fse.remove(bobBuildPath);
       }
-      await buildTypeScript(bobBuildPath, { incremental });
+      await buildTypeScript(bobBuildPath, { tsconfigPath, incremental });
 
       await Promise.all(
         packageInfoList.map(({ cwd, pkg, fullName }) =>


### PR DESCRIPTION
The `tsconfig.json` file is implicitly read to inherit tsc options during the build phase.

However, sometimes you might have multiple config files and use one for build. One common reason is one tsconfig checks the types of all files (including other configs and tests) and another tsconfig specifies what is to be built.

This PR allows for a `--tsconfig` option to directly specify the tsconfig to use.

### TODO

- [ ] Tests