### PR TITLE
Include peerDependenciesMeta in build package.json

### DIFF
--- a/.changeset/pink-fireants-fry.md
+++ b/.changeset/pink-fireants-fry.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': patch
+---
+
+Include peerDependenciesMeta in build package.json

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -335,6 +335,7 @@ function rewritePackageJson(pkg: Record<string, any>, typesOnly: boolean) {
     'version',
     'description',
     'sideEffects',
+    'peerDependenciesMeta',
     'peerDependencies',
     'dependencies',
     'optionalDependencies',


### PR DESCRIPTION
Hello,

`peerDependenciesMeta` should be included in the final package.json. Not including it leads to an issue in [grapql-config](https://github.com/kamilkisiela/graphql-config) where `cosmiconfig-typescript-loader` and `cosmiconfig-toml-loader` are not considered optionals.