### PR TITLE
fix: skip non js files validation (like wasm)

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -403,7 +403,9 @@ export function validatePackageJson(
     const received = get(pkg, key);
     
     // In case the `main` entry of the package.json file was a non JS file (like .wasm), we don't wanna validate the cjs rule, but rather skip the check
-    if(key === 'main' && ["js", "cjs"].includes(received.split(".").pop())) {
+    const fileExt = received.split(".").pop()
+    const jsFilesExt = ["js", "cjs"]
+    if(key === 'main' && jsFilesExt.includes(fileExt)) {
       return;
     } else {
       assert.deepEqual(

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -405,7 +405,7 @@ export function validatePackageJson(
     // In case the `main` entry of the package.json file was a non JS file (like .wasm), we don't wanna validate the cjs rule, but rather skip the check
     const fileExt = received.split(".").pop()
     const jsFilesExt = ["js", "cjs"]
-    if(key === 'main' && jsFilesExt.includes(fileExt)) {
+    if(key === 'main' && !jsFilesExt.includes(fileExt)) {
       return;
     } else {
       assert.deepEqual(

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -401,13 +401,17 @@ export function validatePackageJson(
 ) {
   function expect(key: string, expected: unknown) {
     const received = get(pkg, key);
-
-    assert.deepEqual(
-      received,
-      expected,
-      `${pkg.name}: "${key}" equals "${JSON.stringify(received)}"` +
-        `, should be "${JSON.stringify(expected)}".`,
-    );
+    
+    // In case the `main` entry of the package.json file was a non JS file (like .wasm), we don't wanna validate the cjs rule, but rather skip the check
+    if(key === 'main' && ["js", "cjs"].includes(received.split(".").pop())) {
+      return;
+    } else {
+      assert.deepEqual(
+        received,
+        expected,
+        `${pkg.name}: "${key}" equals "${JSON.stringify(received)}"` +
+          `, should be "${JSON.stringify(expected)}".`,
+      );
   }
 
   // Type only packages have simpler rules (following the style of https://github.com/DefinitelyTyped/DefinitelyTyped packages)


### PR DESCRIPTION
Fixes `main` entry in package.json validation in case it was a non js file
https://github.com/dotansimha/graphql-code-generator/actions/runs/4191404844/jobs/7265822126#step:4:29