### PR TITLE
exports field should exist in types-only builds

### DIFF
--- a/.changeset/yellow-carrots-teach.md
+++ b/.changeset/yellow-carrots-teach.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': patch
+---
+
+exports field should exist in types-only builds

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,11 +1,5 @@
-import { createCommand } from '../command.js';
-import { getBobConfig } from '../config.js';
-import { getRootPackageJSON } from '../utils/get-root-package-json.js';
-import { getWorkspacePackagePaths } from '../utils/get-workspace-package-paths.js';
-import { getWorkspaces } from '../utils/get-workspaces.js';
-import { rewriteExports } from '../utils/rewrite-exports.js';
-import { presetFields, presetFieldsESM } from './bootstrap.js';
 import assert from 'assert';
+import { dirname, join, resolve } from 'path';
 import { Consola } from 'consola';
 import { execa, ExecaReturnValue } from 'execa';
 import fse from 'fs-extra';
@@ -13,7 +7,13 @@ import { globby } from 'globby';
 import get from 'lodash.get';
 import mkdirp from 'mkdirp';
 import pLimit from 'p-limit';
-import { dirname, join, resolve } from 'path';
+import { createCommand } from '../command.js';
+import { getBobConfig } from '../config.js';
+import { getRootPackageJSON } from '../utils/get-root-package-json.js';
+import { getWorkspacePackagePaths } from '../utils/get-workspace-package-paths.js';
+import { getWorkspaces } from '../utils/get-workspaces.js';
+import { rewriteExports } from '../utils/rewrite-exports.js';
+import { presetFields, presetFieldsESM } from './bootstrap.js';
 
 export const DIST_DIR = 'dist';
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -360,6 +360,11 @@ function rewritePackageJson(pkg: Record<string, any>, typesOnly: boolean) {
 
   const distDirStr = `${DIST_DIR}/`;
 
+  if (!pkg.exports) {
+    newPkg.exports = presetFields.exports;
+  }
+  newPkg.exports = rewriteExports(pkg.exports, DIST_DIR, typesOnly);
+
   if (typesOnly) {
     newPkg.main = '';
     delete newPkg.module;
@@ -372,13 +377,6 @@ function rewritePackageJson(pkg: Record<string, any>, typesOnly: boolean) {
   newPkg.typescript = {
     definition: newPkg.typescript.definition.replace(distDirStr, ''),
   };
-
-  if (!typesOnly) {
-    if (!pkg.exports) {
-      newPkg.exports = presetFields.exports;
-    }
-    newPkg.exports = rewriteExports(pkg.exports, DIST_DIR);
-  }
 
   if (pkg.bin) {
     newPkg.bin = {};

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -415,7 +415,10 @@ export function validatePackageJson(
     expect('module', undefined);
     expect('typings', presetFields.typings);
     expect('typescript.definition', presetFields.typescript.definition);
-    expect('exports', undefined);
+    expect("exports['.'].default", {
+      // only the "types" field is required
+      types: presetFields.exports['.'].default.types,
+    });
     return;
   }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,12 +1,3 @@
-import assert from 'assert';
-import { dirname, join, resolve } from 'path';
-import { Consola } from 'consola';
-import { execa, ExecaReturnValue } from 'execa';
-import fse from 'fs-extra';
-import { globby } from 'globby';
-import get from 'lodash.get';
-import mkdirp from 'mkdirp';
-import pLimit from 'p-limit';
 import { createCommand } from '../command.js';
 import { getBobConfig } from '../config.js';
 import { getRootPackageJSON } from '../utils/get-root-package-json.js';
@@ -14,6 +5,15 @@ import { getWorkspacePackagePaths } from '../utils/get-workspace-package-paths.j
 import { getWorkspaces } from '../utils/get-workspaces.js';
 import { rewriteExports } from '../utils/rewrite-exports.js';
 import { presetFields, presetFieldsESM } from './bootstrap.js';
+import assert from 'assert';
+import { Consola } from 'consola';
+import { execa, ExecaReturnValue } from 'execa';
+import fse from 'fs-extra';
+import { globby } from 'globby';
+import get from 'lodash.get';
+import mkdirp from 'mkdirp';
+import pLimit from 'p-limit';
+import { dirname, join, resolve } from 'path';
 
 export const DIST_DIR = 'dist';
 
@@ -360,11 +360,6 @@ function rewritePackageJson(pkg: Record<string, any>, typesOnly: boolean) {
 
   const distDirStr = `${DIST_DIR}/`;
 
-  if (!pkg.exports) {
-    newPkg.exports = presetFields.exports;
-  }
-  newPkg.exports = rewriteExports(pkg.exports, DIST_DIR, typesOnly);
-
   if (typesOnly) {
     newPkg.main = '';
     delete newPkg.module;
@@ -377,6 +372,11 @@ function rewritePackageJson(pkg: Record<string, any>, typesOnly: boolean) {
   newPkg.typescript = {
     definition: newPkg.typescript.definition.replace(distDirStr, ''),
   };
+
+  if (!pkg.exports) {
+    newPkg.exports = presetFields.exports;
+  }
+  newPkg.exports = rewriteExports(pkg.exports, DIST_DIR, typesOnly);
 
   if (pkg.bin) {
     newPkg.bin = {};

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -162,6 +162,12 @@ async function checkExportsMapIntegrity(args: {
     );
   }
 
+  // just check if the types under default exist
+  if (args.typesOnly) {
+    await fse.stat(path.join(args.cwd, (args.packageJSON.exports as any)?.['.']?.default?.types));
+    return;
+  }
+
   const exportsMap = exportsMapResult['data'];
 
   const cjsSkipExports = new Set<string>();

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
@@ -1,6 +1,14 @@
 {
   "name": "c",
   "main": "",
+  "exports": {
+    ".": {
+      "default": {
+        "types": "./dist/typings/index.d.ts"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "typings": "dist/typings/index.d.ts",
   "publishConfig": {
     "directory": "dist",

--- a/test/__fixtures__/simple-monorepo/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/c/package.json
@@ -1,6 +1,14 @@
 {
   "name": "c",
   "main": "",
+  "exports": {
+    ".": {
+      "default": {
+        "types": "./dist/typings/index.d.ts"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "typings": "dist/typings/index.d.ts",
   "publishConfig": {
     "directory": "dist",

--- a/test/__fixtures__/simple-types-only/package.json
+++ b/test/__fixtures__/simple-types-only/package.json
@@ -2,6 +2,14 @@
   "name": "simple-types-only",
   "type": "module",
   "main": "",
+  "exports": {
+    ".": {
+      "default": {
+        "types": "./dist/typings/index.d.ts"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "typings": "dist/typings/index.d.ts",
   "publishConfig": {
     "directory": "dist",

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,5 +1,5 @@
-import { rewriteExports } from '../src/utils/rewrite-exports';
 import { expect, test } from 'vitest';
+import { rewriteExports } from '../src/utils/rewrite-exports';
 
 test('basic exports', () => {
   expect(

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'vitest';
 import { rewriteExports } from '../src/utils/rewrite-exports';
+import { expect, test } from 'vitest';
 
 test('basic exports', () => {
   expect(
@@ -27,6 +27,7 @@ test('basic exports', () => {
         },
       },
       'dist',
+      false,
     ),
   ).toStrictEqual({
     '.': {
@@ -96,6 +97,7 @@ test('with custom exports', () => {
         },
       },
       'dist',
+      false,
     ),
   ).toStrictEqual({
     '.': {
@@ -142,3 +144,5 @@ test('with custom exports', () => {
     },
   });
 });
+
+test.todo('with types-only exports');

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -267,15 +267,23 @@ it('can build a monorepo project', async () => {
     }
   `);
   expect(await fse.readFile(files.c['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "c",
-        "main": "",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
-        }
+    {
+      "name": "c",
+      "main": "",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "exports": {
+        ".": {
+          "default": {
+            "types": "./typings/index.d.ts"
+          }
+        },
+        "./package.json": "./package.json"
       }
-    `);
+    }
+  `);
 
   await execa('node', [binaryFolder, 'check'], {
     cwd: path.resolve(fixturesFolder, 'simple-monorepo'),
@@ -345,6 +353,14 @@ it('can build a types only project', async () => {
       "typings": "typings/index.d.ts",
       "typescript": {
         "definition": "typings/index.d.ts"
+      },
+      "exports": {
+        ".": {
+          "default": {
+            "types": "./typings/index.d.ts"
+          }
+        },
+        "./package.json": "./package.json"
       }
     }
   `);
@@ -560,15 +576,23 @@ it('can build a monorepo pnpm project', async () => {
     }
   `);
   expect(await fse.readFile(files.c['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "c",
-        "main": "",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
-        }
+    {
+      "name": "c",
+      "main": "",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "exports": {
+        ".": {
+          "default": {
+            "types": "./typings/index.d.ts"
+          }
+        },
+        "./package.json": "./package.json"
       }
-    `);
+    }
+  `);
 
   await execa('node', [binaryFolder, 'check'], {
     cwd: path.resolve(fixturesFolder, 'simple-monorepo-pnpm'),


### PR DESCRIPTION
They also exist in the bundles of [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).