### PR TITLE
check node engine is provided in package.json

### DIFF
--- a/.changeset/bob-the-bundler-247-dependencies.md
+++ b/.changeset/bob-the-bundler-247-dependencies.md
@@ -1,7 +1,13 @@
 ---
-"bob-the-bundler": patch
+'bob-the-bundler': patch
 ---
+
 dependencies updates:
-  - Removed dependency [`@vercel/ncc@^0.36.0` ↗︎](https://www.npmjs.com/package/@vercel/ncc/v/0.36.0) (from `dependencies`)
-  - Removed dependency [`dependency-graph@^0.11.0` ↗︎](https://www.npmjs.com/package/dependency-graph/v/0.11.0) (from `dependencies`)
-  - Removed dependency [`tsup@^6.5.0` ↗︎](https://www.npmjs.com/package/tsup/v/6.5.0) (from `dependencies`)
+
+- Removed dependency [`@vercel/ncc@^0.36.0` ↗︎](https://www.npmjs.com/package/@vercel/ncc/v/0.36.0)
+  (from `dependencies`)
+- Removed dependency
+  [`dependency-graph@^0.11.0` ↗︎](https://www.npmjs.com/package/dependency-graph/v/0.11.0) (from
+  `dependencies`)
+- Removed dependency [`tsup@^6.5.0` ↗︎](https://www.npmjs.com/package/tsup/v/6.5.0) (from
+  `dependencies`)

--- a/.changeset/mean-kings-jump.md
+++ b/.changeset/mean-kings-jump.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': major
+---
+
+Require `engines.node` entry with `bob check` command.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -28,6 +28,8 @@ const ExportsMapModel = zod.record(
   ]),
 );
 
+const EnginesModel = zod.record(zod.string(), zod.string());
+
 const BinModel = zod.record(zod.string());
 
 export const checkCommand = createCommand<{}, {}>(api => {
@@ -92,6 +94,9 @@ export const checkCommand = createCommand<{}, {}>(api => {
                 packageJSON: distPackageJSON,
                 skipExports: new Set<string>(config?.check?.skip ?? []),
                 includesCommonJS: config?.commonjs ?? true,
+              });
+              await checkEngines({
+                packageJSON: distPackageJSON,
               });
             } catch (err) {
               api.reporter.error(`Integrity check of '${packageJSON.name}' failed.`);
@@ -313,6 +318,19 @@ async function checkExportsMapIntegrity(args: {
         );
       }
     }
+  }
+}
+
+async function checkEngines(args: {
+  packageJSON: {
+    name: string;
+    engines: unknown;
+  };
+}) {
+  console.log(args.packageJSON);
+  const engines = EnginesModel.safeParse(args.packageJSON.engines);
+  if (engines.success === false || engines.data['node'] === undefined) {
+    throw new Error('Please specify the node engine version in your package.json.');
   }
 }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -327,7 +327,6 @@ async function checkEngines(args: {
     engines: unknown;
   };
 }) {
-  console.log(args.packageJSON);
   const engines = EnginesModel.safeParse(args.packageJSON.engines);
   if (engines.success === false || engines.data['node'] === undefined) {
     throw new Error('Please specify the node engine version in your package.json.');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,30 +1,52 @@
 import zod from 'zod';
 
 const BobConfigModel = zod.optional(
-  zod.union([
-    zod.literal(false),
-    zod.object({
-      commonjs: zod.optional(zod.literal(false), {
-        description: 'Omit CommonJS output.',
-      }),
-      build: zod.union([
-        zod.literal(false),
-        zod.optional(
-          zod.object({
-            copy: zod.optional(zod.array(zod.string())),
-          }),
+  zod.union(
+    [
+      zod.literal(false),
+      zod.object({
+        commonjs: zod.optional(zod.literal(false), {
+          description: 'Omit CommonJS output.',
+        }),
+        build: zod.union(
+          [
+            zod.literal(false),
+            zod.optional(
+              zod.object({
+                copy: zod.optional(zod.array(zod.string()), {
+                  description:
+                    'Specify a list of files that should be copied the the output directory.',
+                }),
+              }),
+            ),
+          ],
+          {
+            description:
+              'Build configuration. Set to false for skipping the build of this package.',
+          },
         ),
-      ]),
-      check: zod.optional(
-        zod.union([
-          zod.literal(false),
-          zod.object({
-            skip: zod.optional(zod.array(zod.string())),
-          }),
-        ]),
-      ),
-    }),
-  ]),
+        check: zod.optional(
+          zod.union([
+            zod.literal(false),
+            zod.object({
+              skip: zod.optional(zod.array(zod.string()), {
+                description:
+                  'Skip certain files from being checked. E.g. modules with side-effects.',
+              }),
+            }),
+          ]),
+          {
+            description:
+              'Check whether the built packages comply with the standards. (ESM & CJS compatible and loadable and Node.js engines specified)',
+          },
+        ),
+      }),
+    ],
+    {
+      description:
+        'Bob configuration. Set this value to false in order to disable running bob on this package.',
+    },
+  ),
 );
 
 export type BobConfig = zod.TypeOf<typeof BobConfigModel>;

--- a/test/__fixtures__/simple-esm-only/package.json
+++ b/test/__fixtures__/simple-esm-only/package.json
@@ -1,6 +1,9 @@
 {
   "name": "simple-esm-only",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/a/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/a/package.json
@@ -1,6 +1,9 @@
 {
   "name": "a",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/b/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "b",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "bin": {
     "bbb": "dist/cjs/log-the-world.js"
   },

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
@@ -1,5 +1,8 @@
 {
   "name": "c",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple-monorepo/packages/a/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/a/package.json
@@ -1,6 +1,9 @@
 {
   "name": "a",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple-monorepo/packages/b/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "b",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "bin": {
     "bbb": "dist/cjs/log-the-world.js"
   },

--- a/test/__fixtures__/simple-monorepo/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/c/package.json
@@ -1,5 +1,8 @@
 {
   "name": "c",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple-types-only/package.json
+++ b/test/__fixtures__/simple-types-only/package.json
@@ -1,6 +1,9 @@
 {
   "name": "simple-types-only",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/simple/package.json
+++ b/test/__fixtures__/simple/package.json
@@ -1,6 +1,9 @@
 {
   "name": "simple",
   "type": "module",
+  "engines": {
+    "node": ">= 12.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/__fixtures__/tsconfig-build-json/package.json
+++ b/test/__fixtures__/tsconfig-build-json/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tsconfig-build-json",
   "type": "module",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -41,6 +41,9 @@ it('can bundle a simple project', async () => {
   expect(await fse.readFile(packageJsonFilePath, 'utf8')).toMatchInlineSnapshot(`
     {
       "name": "simple",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
       "main": "cjs/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",
@@ -132,48 +135,51 @@ it('can build a monorepo project', async () => {
     "export const a = 'WUP';",
   );
   expect(await fse.readFile(files.a['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "a",
-        "main": "cjs/index.js",
-        "module": "esm/index.js",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
+    {
+      "name": "a",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "main": "cjs/index.js",
+      "module": "esm/index.js",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "type": "module",
+      "exports": {
+        ".": {
+          "require": {
+            "types": "./typings/index.d.cts",
+            "default": "./cjs/index.js"
+          },
+          "import": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          },
+          "default": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          }
         },
-        "type": "module",
-        "exports": {
-          ".": {
-            "require": {
-              "types": "./typings/index.d.cts",
-              "default": "./cjs/index.js"
-            },
-            "import": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            },
-            "default": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            }
+        "./*": {
+          "require": {
+            "types": "./typings/*.d.cts",
+            "default": "./cjs/*.js"
           },
-          "./*": {
-            "require": {
-              "types": "./typings/*.d.cts",
-              "default": "./cjs/*.js"
-            },
-            "import": {
-              "types": "./typings/*.d.ts",
-              "default": "./esm/*.js"
-            },
-            "default": {
-              "types": "./typings/*.d.ts",
-              "default": "./esm/*.js"
-            }
+          "import": {
+            "types": "./typings/*.d.ts",
+            "default": "./esm/*.js"
           },
-          "./package.json": "./package.json"
-        }
+          "default": {
+            "types": "./typings/*.d.ts",
+            "default": "./esm/*.js"
+          }
+        },
+        "./package.json": "./package.json"
       }
-    `);
+    }
+  `);
 
   expect(await fse.readFile(files.b['cjs/index.js'], 'utf8')).toMatchInlineSnapshot(`
     "use strict";
@@ -215,51 +221,54 @@ it('can build a monorepo project', async () => {
     }
   `);
   expect(await fse.readFile(files.b['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "b",
-        "main": "cjs/index.js",
-        "module": "esm/index.js",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
-        },
-        "type": "module",
-        "exports": {
-          ".": {
-            "require": {
-              "types": "./typings/index.d.cts",
-              "default": "./cjs/index.js"
-            },
-            "import": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            },
-            "default": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            }
+    {
+      "name": "b",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "main": "cjs/index.js",
+      "module": "esm/index.js",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "type": "module",
+      "exports": {
+        ".": {
+          "require": {
+            "types": "./typings/index.d.cts",
+            "default": "./cjs/index.js"
           },
-          "./foo": {
-            "require": {
-              "types": "./typings/foo.d.cts",
-              "default": "./cjs/foo.js"
-            },
-            "import": {
-              "types": "./typings/foo.d.ts",
-              "default": "./esm/foo.js"
-            },
-            "default": {
-              "types": "./typings/foo.d.ts",
-              "default": "./esm/foo.js"
-            }
+          "import": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
           },
-          "./package.json": "./package.json"
+          "default": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          }
         },
-        "bin": {
-          "bbb": "cjs/log-the-world.js"
-        }
+        "./foo": {
+          "require": {
+            "types": "./typings/foo.d.cts",
+            "default": "./cjs/foo.js"
+          },
+          "import": {
+            "types": "./typings/foo.d.ts",
+            "default": "./esm/foo.js"
+          },
+          "default": {
+            "types": "./typings/foo.d.ts",
+            "default": "./esm/foo.js"
+          }
+        },
+        "./package.json": "./package.json"
+      },
+      "bin": {
+        "bbb": "cjs/log-the-world.js"
       }
-    `);
+    }
+  `);
 
   expect(await fse.readFile(files.c['cjs/index.js'], 'utf8')).toMatchInlineSnapshot('');
   expect(await fse.readFile(files.c['esm/index.js'], 'utf8')).toMatchInlineSnapshot('');
@@ -271,6 +280,9 @@ it('can build a monorepo project', async () => {
   expect(await fse.readFile(files.c['package.json'], 'utf8')).toMatchInlineSnapshot(`
     {
       "name": "c",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
       "main": "cjs/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",
@@ -316,6 +328,9 @@ it('can build an esm only project', async () => {
   expect(await fse.readFile(packageJsonFilePath, 'utf8')).toMatchInlineSnapshot(`
     {
       "name": "simple-esm-only",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
       "main": "esm/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",
@@ -361,6 +376,9 @@ it('can build a types only project', async () => {
   expect(await fse.readFile(packageJsonFilePath, 'utf8')).toMatchInlineSnapshot(`
     {
       "name": "simple-types-only",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
       "main": "cjs/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",
@@ -467,48 +485,51 @@ it('can build a monorepo pnpm project', async () => {
     "export const a = 'WUP';",
   );
   expect(await fse.readFile(files.a['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "a",
-        "main": "cjs/index.js",
-        "module": "esm/index.js",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
+    {
+      "name": "a",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "main": "cjs/index.js",
+      "module": "esm/index.js",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "type": "module",
+      "exports": {
+        ".": {
+          "require": {
+            "types": "./typings/index.d.cts",
+            "default": "./cjs/index.js"
+          },
+          "import": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          },
+          "default": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          }
         },
-        "type": "module",
-        "exports": {
-          ".": {
-            "require": {
-              "types": "./typings/index.d.cts",
-              "default": "./cjs/index.js"
-            },
-            "import": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            },
-            "default": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            }
+        "./*": {
+          "require": {
+            "types": "./typings/*.d.cts",
+            "default": "./cjs/*.js"
           },
-          "./*": {
-            "require": {
-              "types": "./typings/*.d.cts",
-              "default": "./cjs/*.js"
-            },
-            "import": {
-              "types": "./typings/*.d.ts",
-              "default": "./esm/*.js"
-            },
-            "default": {
-              "types": "./typings/*.d.ts",
-              "default": "./esm/*.js"
-            }
+          "import": {
+            "types": "./typings/*.d.ts",
+            "default": "./esm/*.js"
           },
-          "./package.json": "./package.json"
-        }
+          "default": {
+            "types": "./typings/*.d.ts",
+            "default": "./esm/*.js"
+          }
+        },
+        "./package.json": "./package.json"
       }
-    `);
+    }
+  `);
 
   expect(await fse.readFile(files.b['cjs/index.js'], 'utf8')).toMatchInlineSnapshot(`
     "use strict";
@@ -550,51 +571,54 @@ it('can build a monorepo pnpm project', async () => {
     }
   `);
   expect(await fse.readFile(files.b['package.json'], 'utf8')).toMatchInlineSnapshot(`
-      {
-        "name": "b",
-        "main": "cjs/index.js",
-        "module": "esm/index.js",
-        "typings": "typings/index.d.ts",
-        "typescript": {
-          "definition": "typings/index.d.ts"
-        },
-        "type": "module",
-        "exports": {
-          ".": {
-            "require": {
-              "types": "./typings/index.d.cts",
-              "default": "./cjs/index.js"
-            },
-            "import": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            },
-            "default": {
-              "types": "./typings/index.d.ts",
-              "default": "./esm/index.js"
-            }
+    {
+      "name": "b",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "main": "cjs/index.js",
+      "module": "esm/index.js",
+      "typings": "typings/index.d.ts",
+      "typescript": {
+        "definition": "typings/index.d.ts"
+      },
+      "type": "module",
+      "exports": {
+        ".": {
+          "require": {
+            "types": "./typings/index.d.cts",
+            "default": "./cjs/index.js"
           },
-          "./foo": {
-            "require": {
-              "types": "./typings/foo.d.cts",
-              "default": "./cjs/foo.js"
-            },
-            "import": {
-              "types": "./typings/foo.d.ts",
-              "default": "./esm/foo.js"
-            },
-            "default": {
-              "types": "./typings/foo.d.ts",
-              "default": "./esm/foo.js"
-            }
+          "import": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
           },
-          "./package.json": "./package.json"
+          "default": {
+            "types": "./typings/index.d.ts",
+            "default": "./esm/index.js"
+          }
         },
-        "bin": {
-          "bbb": "cjs/log-the-world.js"
-        }
+        "./foo": {
+          "require": {
+            "types": "./typings/foo.d.cts",
+            "default": "./cjs/foo.js"
+          },
+          "import": {
+            "types": "./typings/foo.d.ts",
+            "default": "./esm/foo.js"
+          },
+          "default": {
+            "types": "./typings/foo.d.ts",
+            "default": "./esm/foo.js"
+          }
+        },
+        "./package.json": "./package.json"
+      },
+      "bin": {
+        "bbb": "cjs/log-the-world.js"
       }
-    `);
+    }
+  `);
 
   expect(await fse.readFile(files.c['cjs/index.js'], 'utf8')).toMatchInlineSnapshot('');
   expect(await fse.readFile(files.c['esm/index.js'], 'utf8')).toMatchInlineSnapshot('');
@@ -606,6 +630,9 @@ it('can build a monorepo pnpm project', async () => {
   expect(await fse.readFile(files.c['package.json'], 'utf8')).toMatchInlineSnapshot(`
     {
       "name": "c",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
       "main": "cjs/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",
@@ -650,6 +677,9 @@ it('can bundle a tsconfig-build-json project', async () => {
     .toMatchInlineSnapshot(`
     {
       "name": "tsconfig-build-json",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
       "main": "cjs/index.js",
       "module": "esm/index.js",
       "typings": "typings/index.d.ts",


### PR DESCRIPTION
Closes https://github.com/kamilkisiela/bob/issues/246

I am still not 100% sure whether we should ensure this - as people could also be building browser-only packages. 🤔 
Right now the `bob check` command assumes the files are loadable by Node.js anyways. 🤔 