### PR TITLE
Build modern CommonJS and support package.json exports

### DIFF
--- a/.changeset/bob-the-bundler-336-dependencies.md
+++ b/.changeset/bob-the-bundler-336-dependencies.md
@@ -1,0 +1,5 @@
+---
+"bob-the-bundler": patch
+---
+dependencies updates:
+  - Added dependency [`get-tsconfig@^4.8.1` ↗︎](https://www.npmjs.com/package/get-tsconfig/v/4.8.1) (to `dependencies`)

--- a/.changeset/thin-mails-clap.md
+++ b/.changeset/thin-mails-clap.md
@@ -1,5 +1,5 @@
 ---
-'bob-the-bundler': minor
+'bob-the-bundler': major
 ---
 
 Build modern CommonJS and support package.json exports

--- a/.changeset/thin-mails-clap.md
+++ b/.changeset/thin-mails-clap.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': minor
+---
+
+Build modern CommonJS and support package.json exports

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "consola": "^3.0.0",
     "execa": "^9.0.0",
     "fs-extra": "^11.1.0",
+    "get-tsconfig": "^4.8.1",
     "globby": "^14.0.0",
     "js-yaml": "^4.1.0",
     "lodash.get": "^4.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       fs-extra:
         specifier: ^11.1.0
         version: 11.3.0
+      get-tsconfig:
+        specifier: ^4.8.1
+        version: 4.8.1
       globby:
         specifier: ^14.0.0
         version: 14.0.2
@@ -1160,6 +1163,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1780,6 +1786,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
@@ -3439,6 +3448,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.7
 
+  get-tsconfig@4.8.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4032,6 +4045,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve.exports@2.0.3: {}
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -487,7 +487,7 @@ export function validatePackageJson(
 type PackageJsonType = 'module' | 'commonjs';
 
 /**
- * Sets the {@link filePath package.json} `"type"` field to the defined {@link type}
+ * Sets the {@link cwd workspaces} package.json(s) `"type"` field to the defined {@link type}
  * returning a "revert" function which puts the original `"type"` back.
  *
  * @returns A revert function that reverts the original value of the `"type"` field.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -84,7 +84,10 @@ async function buildTypeScript(
   }
 
   async function build(out: PackageJsonType) {
-    const revertPackageJsonsType = await setPackageJsonsType(options.cwd, out);
+    const revertPackageJsonsType = await setPackageJsonsType(
+      { cwd: options.cwd, ignore: [...filesToExcludeFromDist, ...(tsconfig?.exclude || [])] },
+      out,
+    );
     try {
       assertTypeScriptBuildResult(
         await execa('npx', [
@@ -501,7 +504,7 @@ type PackageJsonType = 'module' | 'commonjs';
  * @returns A revert function that reverts the original value of the `"type"` field.
  */
 async function setPackageJsonsType(
-  cwd: string,
+  { cwd, ignore }: { cwd: string; ignore: string[] },
   type: PackageJsonType,
 ): Promise<() => Promise<void>> {
   const rootPkgJsonPath = join(cwd, 'package.json');
@@ -519,7 +522,7 @@ async function setPackageJsonsType(
       ? []
       : await globby(
           workspaces.map((w: string) => w + '/package.json'),
-          { cwd, absolute: true },
+          { cwd, absolute: true, ignore },
         )),
   ]) {
     const contents =

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -505,7 +505,7 @@ async function setPackageJsonsType(
   const reverts: (() => Promise<void>)[] = [];
 
   for (const pkgJsonPath of [
-    // we also want to modify the root package.json TODO: do we?
+    // we also want to modify the root package.json TODO: do we in single package repos?
     rootPkgJsonPath,
     ...(isSinglePackage
       ? []

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -41,6 +41,12 @@ const filesToExcludeFromDist = [
   '**/temp',
 ];
 
+function compilerOptionsToArgs(options: Record<string, unknown>): string[] {
+  return Object.entries(options)
+    .filter(([, value]) => !!value)
+    .flatMap(([key, value]) => [`--${key}`, `${value}`]);
+}
+
 function assertTypeScriptBuildResult(
   result: Awaited<ReturnType<typeof execa>>,
   reporter: ConsolaInstance,
@@ -65,13 +71,14 @@ async function buildTypeScript(
     assertTypeScriptBuildResult(
       await execa('npx', [
         'tsc',
-        ...(tsconfig ? ['--project', tsconfig] : []),
-        '--module node16', // not nodenext because this keeps up with latest node and we dont want to break something suddenly
-        '--sourceMap false',
-        '--inlineSourceMap false',
-        ...(options.incremental ? ['--incremental'] : []),
-        '--outDir',
-        outDir,
+        ...compilerOptionsToArgs({
+          project: tsconfig,
+          module: 'node16',
+          sourceMap: false,
+          inlineSourceMap: false,
+          incremental: options.incremental,
+          outDir,
+        }),
       ]),
       reporter,
     );

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -33,7 +33,7 @@ it('can bundle a simple project', async () => {
     export default _default;
   `);
   expect(await fse.readFile(indexMjsFilePath, 'utf8')).toMatchInlineSnapshot(`
-    export const someNumber = 1;
+    export var someNumber = 1;
     export default 'kek';
   `);
   expect(await fse.readFile(readmeFilePath, 'utf8')).toMatchInlineSnapshot('Hello!');
@@ -355,7 +355,7 @@ it('can build an esm only project', async () => {
   `);
 
   expect(await fse.readFile(indexJsFilePath, 'utf8')).toMatchInlineSnapshot(
-    `export const someNumber = 1;`,
+    `export var someNumber = 1;`,
   );
   expect(await fse.readFile(indexDtsFilePath, 'utf8')).toMatchInlineSnapshot(
     'export declare const someNumber = 1;',
@@ -732,7 +732,7 @@ it('can bundle a tsconfig-build-json project', async () => {
   `);
   await expect(fse.readFile(path.resolve(baseDistPath, 'esm', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export const hello = 1;
+    export var hello = 1;
     export default 'there';
   `);
 
@@ -776,7 +776,7 @@ it('can bundle a simple project with additional exports', async () => {
   `);
   await expect(fse.readFile(path.join(dist, 'esm', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export const someLetter = 'a';
+    export var someLetter = 'a';
     export default { b: 'c' };
   `);
 
@@ -798,7 +798,7 @@ it('can bundle a simple project with additional exports', async () => {
   `);
   await expect(fse.readFile(path.join(dist, 'esm', 'sub', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export const someOtherLetter = 'd';
+    export var someOtherLetter = 'd';
     export default { e: 'f' };
   `);
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -204,7 +204,7 @@ it('can build a monorepo project', async () => {
     __exportStar(require("./foo.js"), exports);
     exports.b = 'SUP' + foo_js_1.b;
     function foo() {
-        return Promise.resolve().then(() => require('./foo.js'));
+        return import('./foo.js');
     }
   `);
   expect(await fse.readFile(files.b['typings/index.d.ts'], 'utf8')).toMatchInlineSnapshot(`
@@ -552,7 +552,7 @@ it('can build a monorepo pnpm project', async () => {
     __exportStar(require("./foo.js"), exports);
     exports.b = 'SUP' + foo_js_1.b;
     function foo() {
-        return Promise.resolve().then(() => require('./foo.js'));
+        return import('./foo.js');
     }
   `);
   expect(await fse.readFile(files.b['typings/index.d.ts'], 'utf8')).toMatchInlineSnapshot(`

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -33,7 +33,7 @@ it('can bundle a simple project', async () => {
     export default _default;
   `);
   expect(await fse.readFile(indexMjsFilePath, 'utf8')).toMatchInlineSnapshot(`
-    export var someNumber = 1;
+    export const someNumber = 1;
     export default 'kek';
   `);
   expect(await fse.readFile(readmeFilePath, 'utf8')).toMatchInlineSnapshot('Hello!');
@@ -355,7 +355,7 @@ it('can build an esm only project', async () => {
   `);
 
   expect(await fse.readFile(indexJsFilePath, 'utf8')).toMatchInlineSnapshot(
-    'export var someNumber = 1;',
+    `export const someNumber = 1;`,
   );
   expect(await fse.readFile(indexDtsFilePath, 'utf8')).toMatchInlineSnapshot(
     'export declare const someNumber = 1;',
@@ -732,7 +732,7 @@ it('can bundle a tsconfig-build-json project', async () => {
   `);
   await expect(fse.readFile(path.resolve(baseDistPath, 'esm', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export var hello = 1;
+    export const hello = 1;
     export default 'there';
   `);
 
@@ -776,7 +776,7 @@ it('can bundle a simple project with additional exports', async () => {
   `);
   await expect(fse.readFile(path.join(dist, 'esm', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export var someLetter = 'a';
+    export const someLetter = 'a';
     export default { b: 'c' };
   `);
 
@@ -798,7 +798,7 @@ it('can bundle a simple project with additional exports', async () => {
   `);
   await expect(fse.readFile(path.join(dist, 'esm', 'sub', 'index.js'), 'utf8')).resolves
     .toMatchInlineSnapshot(`
-    export var someOtherLetter = 'd';
+    export const someOtherLetter = 'd';
     export default { e: 'f' };
   `);
 


### PR DESCRIPTION
### Use `node16` for building CJS

> [!WARNING]  
> Unless `moduleResolution` is explicitly set to `classic`, `node` or `node10` - then `commonjs` (Node <v12 style CJS) will be used.

Output leaves dynamic `import()` calls as-is, so CommonJS can asynchronously import ESM ([Node can import ESM from CJS](https://nodejs.org/api/esm.html#import-statements)).

> `node16` and `nodenext` are the only correct `module` options for all apps and libraries that are intended to run in Node.js v12 or later, whether they use ES modules or not.

_[TypeScript documentation](https://www.typescriptlang.org/docs/handbook/modules/reference.html#summary)_

Node.js v12 security support [reached EOL in 2022 (and active support in 2020)](https://endoflife.date/nodejs).

### Use `node16` or `nodenext` or `es2022` for building ESM

If the nearest tsconfig.json's `moduleResolution` is either `node16` or `nodenext`, the `module` will use that value. Otherwise, it'll use `es2022`.

---

Aside from building to "modern" CJS, another benefit of using `module: node16` is that it works with `moduleResolution: node16 | nodenext` (allowing the usage of [`exports` field in package.json](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#exports)) whereas `module: commonjs` doesn't.
