### PR TITLE
Correct fields in package.json

### DIFF
--- a/.changeset/bright-drinks-provide.md
+++ b/.changeset/bright-drinks-provide.md
@@ -1,0 +1,7 @@
+---
+'bob-the-bundler': major
+---
+
+Drop "module" package.json field
+
+The field was just a proposal and was never officially (and fully) defined by Node. Node instead uses (and recommends) the ["exports" field](https://nodejs.org/api/packages.html#exports).

--- a/.changeset/rare-lemons-count.md
+++ b/.changeset/rare-lemons-count.md
@@ -1,0 +1,5 @@
+---
+'bob-the-bundler': major
+---
+
+Drop "typescript" package.json field

--- a/.changeset/wise-tigers-roll.md
+++ b/.changeset/wise-tigers-roll.md
@@ -1,0 +1,13 @@
+---
+'bob-the-bundler': major
+---
+
+"main" package.json field matches the location of "type" output
+
+> The "type" field defines the module format that Node.js uses for all .js files that have that package.json file as their nearest parent.
+>
+> Files ending with .js are loaded as ES modules when the nearest parent package.json file contains a top-level field "type" with a value of "module".
+>
+> If the nearest parent package.json lacks a "type" field, or contains "type": "commonjs", .js files are treated as CommonJS. If the volume root is reached and no package.json is found, .js files are treated as CommonJS.
+
+_[Node documentation](https://nodejs.org/api/packages.html#type)_

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -12,12 +12,8 @@ import { rewriteCodeImports } from '../utils/rewrite-code-imports.js';
 /** The default bob fields that should be within a package.json */
 export const presetFields = Object.freeze({
   type: 'module',
-  main: 'dist/cjs/index.js',
-  module: 'dist/esm/index.js',
+  main: 'dist/esm/index.js',
   typings: 'dist/typings/index.d.ts',
-  typescript: {
-    definition: 'dist/typings/index.d.ts',
-  },
   exports: {
     '.': {
       require: {
@@ -45,11 +41,7 @@ export const presetFields = Object.freeze({
 export const presetFieldsESM = {
   type: 'module',
   main: 'dist/esm/index.js',
-  module: 'dist/esm/index.js',
   typings: 'dist/typings/index.d.ts',
-  typescript: {
-    definition: 'dist/typings/index.d.ts',
-  },
   exports: {
     '.': {
       import: {

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -10,7 +10,7 @@ import { getWorkspaces } from '../utils/get-workspaces.js';
 import { rewriteCodeImports } from '../utils/rewrite-code-imports.js';
 
 /** The default bob fields that should be within a package.json */
-export const presetFields = Object.freeze({
+export const presetFieldsDual = Object.freeze({
   type: 'module',
   main: 'dist/esm/index.js',
   typings: 'dist/typings/index.d.ts',
@@ -38,7 +38,7 @@ export const presetFields = Object.freeze({
   },
 });
 
-export const presetFieldsESM = {
+export const presetFieldsOnlyESM = {
   type: 'module',
   main: 'dist/esm/index.js',
   typings: 'dist/typings/index.d.ts',
@@ -85,7 +85,7 @@ async function applyPackageJSONPresetConfig(
   packageJSONPath: string,
   packageJSON: Record<string, unknown>,
 ) {
-  Object.assign(packageJSON, presetFields);
+  Object.assign(packageJSON, presetFieldsDual);
   await fse.writeFile(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -440,14 +440,10 @@ export function validatePackageJson(
   if (Object.keys(pkg.bin ?? {}).length > 0) {
     if (opts.includesCommonJS === true) {
       expect('main', presetFields.main);
-      expect('module', presetFields.module);
       expect('typings', presetFields.typings);
-      expect('typescript.definition', presetFields.typescript.definition);
     } else {
       expect('main', presetFieldsESM.main);
-      expect('module', presetFieldsESM.module);
       expect('typings', presetFieldsESM.typings);
-      expect('typescript.definition', presetFieldsESM.typescript.definition);
     }
   } else if (
     pkg.main !== undefined ||
@@ -459,9 +455,7 @@ export function validatePackageJson(
     if (opts.includesCommonJS === true) {
       // if there is no bin property, we NEED to check the exports.
       expect('main', presetFields.main);
-      expect('module', presetFields.module);
       expect('typings', presetFields.typings);
-      expect('typescript.definition', presetFields.typescript.definition);
 
       // For now we enforce a top level exports property
       expect("exports['.'].require", presetFields.exports['.'].require);
@@ -469,9 +463,7 @@ export function validatePackageJson(
       expect("exports['.'].default", presetFields.exports['.'].default);
     } else {
       expect('main', presetFieldsESM.main);
-      expect('module', presetFieldsESM.module);
       expect('typings', presetFieldsESM.typings);
-      expect('typescript.definition', presetFieldsESM.typescript.definition);
 
       // For now, we enforce a top level exports property
       expect("exports['.']", presetFieldsESM.exports['.']);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -12,7 +12,7 @@ import { getRootPackageJSON } from '../utils/get-root-package-json.js';
 import { getWorkspacePackagePaths } from '../utils/get-workspace-package-paths.js';
 import { getWorkspaces } from '../utils/get-workspaces.js';
 import { rewriteExports } from '../utils/rewrite-exports.js';
-import { presetFields, presetFieldsESM } from './bootstrap.js';
+import { presetFieldsDual, presetFieldsOnlyESM } from './bootstrap.js';
 
 export const DIST_DIR = 'dist';
 
@@ -227,9 +227,9 @@ async function build({
     return;
   }
 
-  validatePackageJson(pkg, {
-    includesCommonJS: config?.commonjs ?? true,
-  });
+  const dual = config?.commonjs ?? true;
+
+  validatePackageJson(pkg, { dual });
 
   const declarations = await globby('**/*.d.ts', {
     cwd: getBuildPath('esm'),
@@ -269,7 +269,7 @@ async function build({
     ),
   );
 
-  if (config?.commonjs === undefined) {
+  if (dual) {
     // Transpile ESM to CJS and move CJS to dist/cjs only if there's something to transpile
     await fse.ensureDir(join(distPath, 'cjs'));
 
@@ -369,9 +369,7 @@ function rewritePackageJson(pkg: Record<string, any>) {
     'engines',
     'name',
     'main',
-    'module',
     'typings',
-    'typescript',
     'type',
   ];
 
@@ -393,14 +391,10 @@ function rewritePackageJson(pkg: Record<string, any>) {
   const distDirStr = `${DIST_DIR}/`;
 
   newPkg.main = newPkg.main.replace(distDirStr, '');
-  newPkg.module = newPkg.module.replace(distDirStr, '');
   newPkg.typings = newPkg.typings.replace(distDirStr, '');
-  newPkg.typescript = {
-    definition: newPkg.typescript.definition.replace(distDirStr, ''),
-  };
 
   if (!pkg.exports) {
-    newPkg.exports = presetFields.exports;
+    newPkg.exports = presetFieldsDual.exports;
   }
   newPkg.exports = rewriteExports(pkg.exports, DIST_DIR);
 
@@ -418,7 +412,7 @@ function rewritePackageJson(pkg: Record<string, any>) {
 export function validatePackageJson(
   pkg: any,
   opts: {
-    includesCommonJS: boolean;
+    dual: boolean;
   },
 ) {
   function expect(key: string, expected: unknown) {
@@ -438,35 +432,29 @@ export function validatePackageJson(
   // 2. have an exports property
   // 3. have an exports and bin property
   if (Object.keys(pkg.bin ?? {}).length > 0) {
-    if (opts.includesCommonJS === true) {
-      expect('main', presetFields.main);
-      expect('typings', presetFields.typings);
+    if (opts.dual === true) {
+      expect('main', presetFieldsDual.main);
+      expect('typings', presetFieldsDual.typings);
     } else {
-      expect('main', presetFieldsESM.main);
-      expect('typings', presetFieldsESM.typings);
+      expect('main', presetFieldsOnlyESM.main);
+      expect('typings', presetFieldsOnlyESM.typings);
     }
-  } else if (
-    pkg.main !== undefined ||
-    pkg.module !== undefined ||
-    pkg.exports !== undefined ||
-    pkg.typings !== undefined ||
-    pkg.typescript !== undefined
-  ) {
-    if (opts.includesCommonJS === true) {
+  } else if (pkg.main !== undefined || pkg.exports !== undefined || pkg.typings !== undefined) {
+    if (opts.dual === true) {
       // if there is no bin property, we NEED to check the exports.
-      expect('main', presetFields.main);
-      expect('typings', presetFields.typings);
+      expect('main', presetFieldsDual.main);
+      expect('typings', presetFieldsDual.typings);
 
       // For now we enforce a top level exports property
-      expect("exports['.'].require", presetFields.exports['.'].require);
-      expect("exports['.'].import", presetFields.exports['.'].import);
-      expect("exports['.'].default", presetFields.exports['.'].default);
+      expect("exports['.'].require", presetFieldsDual.exports['.'].require);
+      expect("exports['.'].import", presetFieldsDual.exports['.'].import);
+      expect("exports['.'].default", presetFieldsDual.exports['.'].default);
     } else {
-      expect('main', presetFieldsESM.main);
-      expect('typings', presetFieldsESM.typings);
+      expect('main', presetFieldsOnlyESM.main);
+      expect('typings', presetFieldsOnlyESM.typings);
 
       // For now, we enforce a top level exports property
-      expect("exports['.']", presetFieldsESM.exports['.']);
+      expect("exports['.']", presetFieldsOnlyESM.exports['.']);
     }
   }
 }

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -10,7 +10,7 @@ import { getBobConfig } from '../config.js';
 import { getRootPackageJSON } from '../utils/get-root-package-json.js';
 import { getWorkspacePackagePaths } from '../utils/get-workspace-package-paths.js';
 import { getWorkspaces } from '../utils/get-workspaces.js';
-import { presetFields } from './bootstrap.js';
+import { presetFieldsDual } from './bootstrap.js';
 
 const ExportsMapEntry = zod.object({
   default: zod.string(),
@@ -131,7 +131,7 @@ async function checkExportsMapIntegrity(args: {
       "Missing exports map within the 'package.json'.\n" +
         exportsMapResult.error.message +
         '\nCorrect Example:\n' +
-        JSON.stringify(presetFields.exports, null, 2),
+        JSON.stringify(presetFieldsDual.exports, null, 2),
     );
   }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -93,7 +93,7 @@ export const checkCommand = createCommand<{}, {}>(api => {
                 cwd: path.join(cwd, 'dist'),
                 packageJSON: distPackageJSON,
                 skipExports: new Set<string>(config?.check?.skip ?? []),
-                includesCommonJS: config?.commonjs ?? true,
+                dual: config?.commonjs ?? true,
               });
               await checkEngines({
                 packageJSON: distPackageJSON,
@@ -119,11 +119,11 @@ async function checkExportsMapIntegrity(args: {
   cwd: string;
   packageJSON: {
     name: string;
-    exports: unknown;
+    exports: any;
     bin: unknown;
   };
   skipExports: Set<string>;
-  includesCommonJS: boolean;
+  dual: boolean;
 }) {
   const exportsMapResult = ExportsMapModel.safeParse(args.packageJSON['exports']);
   if (exportsMapResult.success === false) {
@@ -140,7 +140,7 @@ async function checkExportsMapIntegrity(args: {
   const cjsSkipExports = new Set<string>();
   const esmSkipExports = new Set<string>();
   for (const definedExport of args.skipExports) {
-    if (args.includesCommonJS) {
+    if (args.dual) {
       const cjsResult = resolve.resolve(args.packageJSON, definedExport, {
         require: true,
       })?.[0];
@@ -155,7 +155,7 @@ async function checkExportsMapIntegrity(args: {
   }
 
   for (const key of Object.keys(exportsMap)) {
-    if (args.includesCommonJS) {
+    if (args.dual) {
       const cjsResult = resolve.resolve(args.packageJSON, key, {
         require: true,
       })?.[0];
@@ -208,9 +208,8 @@ async function checkExportsMapIntegrity(args: {
     }
 
     const esmResult = resolve.resolve({ exports: exportsMap }, key)?.[0];
-
     if (!esmResult) {
-      throw new Error(`Could not resolve CommonJS import '${key}' for '${args.packageJSON.name}'.`);
+      throw new Error(`Could not resolve export '${key}' in '${args.packageJSON.name}'.`);
     }
 
     if (esmResult.match(/.(js|mjs)$/)) {
@@ -247,40 +246,38 @@ async function checkExportsMapIntegrity(args: {
     }
   }
 
-  const legacyRequire = resolve.legacy(args.packageJSON, {
-    fields: ['main'],
-  });
-  if (!legacyRequire || typeof legacyRequire !== 'string') {
-    throw new Error(`Could not resolve legacy CommonJS entrypoint.`);
+  const exportsRequirePath = resolve.resolve({ exports: exportsMap }, '.', { require: true })?.[0];
+  if (!exportsRequirePath || typeof exportsRequirePath !== 'string') {
+    throw new Error('Could not resolve default CommonJS entrypoint in a Module project.');
   }
 
-  if (args.includesCommonJS) {
-    const legacyRequireResult = await runRequireJSFileCommand({
-      path: legacyRequire,
+  if (args.dual) {
+    const requireResult = await runRequireJSFileCommand({
+      path: exportsRequirePath,
       cwd: args.cwd,
     });
 
-    if (legacyRequireResult.exitCode !== 0) {
+    if (requireResult.exitCode !== 0) {
       throw new Error(
-        `Require of file '${legacyRequire}' failed with error:\n` + legacyRequireResult.stderr,
+        `Require of file '${exportsRequirePath}' failed with error:\n` + requireResult.stderr,
       );
     }
   } else {
-    const legacyRequireResult = await runImportJSFileCommand({
-      path: legacyRequire,
+    const importResult = await runImportJSFileCommand({
+      path: exportsRequirePath,
       cwd: args.cwd,
     });
 
-    if (legacyRequireResult.exitCode !== 0) {
+    if (importResult.exitCode !== 0) {
       throw new Error(
-        `Require of file '${legacyRequire}' failed with error:\n` + legacyRequireResult.stderr,
+        `Import of file '${exportsRequirePath}' failed with error:\n` + importResult.stderr,
       );
     }
   }
 
   const legacyImport = resolve.legacy(args.packageJSON);
   if (!legacyImport || typeof legacyImport !== 'string') {
-    throw new Error(`Could not resolve legacy ESM entrypoint.`);
+    throw new Error('Could not resolve default ESM entrypoint.');
   }
   const legacyImportResult = await runImportJSFileCommand({
     path: legacyImport,
@@ -288,7 +285,7 @@ async function checkExportsMapIntegrity(args: {
   });
   if (legacyImportResult.exitCode !== 0) {
     throw new Error(
-      `Require of file '${legacyRequire}' failed with error:\n` + legacyImportResult.stderr,
+      `Require of file '${exportsRequirePath}' failed with error:\n` + legacyImportResult.stderr,
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,13 @@ const BobConfigModel = zod.optional(
     [
       zod.literal(false),
       zod.object({
-        commonjs: zod.optional(zod.literal(false), {
-          description: 'Omit CommonJS output.',
-        }),
+        commonjs: zod
+          .boolean({
+            description:
+              'Enable CommonJS output creating a dual output ESM+CJS. If set to `false`, will generate only ESM output.',
+          })
+          .optional()
+          .default(true),
         build: zod.union(
           [
             zod.literal(false),

--- a/test/__fixtures__/simple-esm-only/package.json
+++ b/test/__fixtures__/simple-esm-only/package.json
@@ -5,7 +5,6 @@
     "node": ">= 14.0.0"
   },
   "main": "dist/esm/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": {
@@ -26,8 +25,5 @@
   },
   "bob": {
     "commonjs": false
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-exports/package.json
+++ b/test/__fixtures__/simple-exports/package.json
@@ -5,8 +5,7 @@
     "node": ">= 12.0.0",
     "pnpm": ">= 8.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -42,8 +41,5 @@
   "publishConfig": {
     "directory": "dist",
     "access": "public"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/a/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/a/package.json
@@ -4,8 +4,7 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -44,8 +43,5 @@
   },
   "buildOptions": {
     "input": "./src/index.ts"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/b/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/b/package.json
@@ -7,8 +7,7 @@
   "bin": {
     "bbb": "dist/cjs/log-the-world.js"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -47,8 +46,5 @@
   },
   "buildOptions": {
     "input": "./src/index.ts"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
@@ -1,9 +1,10 @@
 {
   "name": "c",
+  "type": "module",
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {

--- a/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo-pnpm/packages/c/package.json
@@ -4,7 +4,6 @@
     "node": ">= 14.0.0"
   },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -29,8 +28,5 @@
   },
   "buildOptions": {
     "input": "./src/index.ts"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-monorepo/packages/a/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/a/package.json
@@ -4,8 +4,7 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {

--- a/test/__fixtures__/simple-monorepo/packages/b/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/b/package.json
@@ -7,8 +7,7 @@
   "bin": {
     "bbb": "dist/cjs/log-the-world.js"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -47,8 +46,5 @@
   },
   "buildOptions": {
     "input": "./src/index.ts"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-monorepo/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/c/package.json
@@ -1,9 +1,10 @@
 {
   "name": "c",
+  "type": "module",
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {

--- a/test/__fixtures__/simple-monorepo/packages/c/package.json
+++ b/test/__fixtures__/simple-monorepo/packages/c/package.json
@@ -4,7 +4,6 @@
     "node": ">= 14.0.0"
   },
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -29,8 +28,5 @@
   },
   "buildOptions": {
     "input": "./src/index.ts"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple-types-only/package.json
+++ b/test/__fixtures__/simple-types-only/package.json
@@ -4,8 +4,7 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -40,8 +39,5 @@
         "./file-that-throws"
       ]
     }
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/simple/package.json
+++ b/test/__fixtures__/simple/package.json
@@ -5,8 +5,7 @@
     "node": ">= 12.0.0",
     "pnpm": ">= 8.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -56,8 +55,5 @@
         "./file-that-throws"
       ]
     }
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/__fixtures__/tsconfig-build-json/package.json
+++ b/test/__fixtures__/tsconfig-build-json/package.json
@@ -4,8 +4,7 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/esm/index.js",
   "exports": {
     ".": {
       "require": {
@@ -42,8 +41,5 @@
   "publishConfig": {
     "directory": "dist",
     "access": "public"
-  },
-  "typescript": {
-    "definition": "dist/typings/index.d.ts"
   }
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -44,12 +44,8 @@ it('can bundle a simple project', async () => {
       "engines": {
         "node": ">= 12.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -140,12 +136,8 @@ it('can build a monorepo project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -226,12 +218,8 @@ it('can build a monorepo project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -283,12 +271,9 @@ it('can build a monorepo project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
+      "type": "module",
       "exports": {
         ".": {
           "require": {
@@ -332,11 +317,7 @@ it('can build an esm only project', async () => {
         "node": ">= 14.0.0"
       },
       "main": "esm/index.js",
-      "module": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -379,12 +360,8 @@ it('can build a types only project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -488,12 +465,8 @@ it('can build a monorepo pnpm project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -574,12 +547,8 @@ it('can build a monorepo pnpm project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -631,12 +600,9 @@ it('can build a monorepo pnpm project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
+      "type": "module",
       "exports": {
         ".": {
           "require": {
@@ -678,12 +644,8 @@ it('can bundle a tsconfig-build-json project', async () => {
       "engines": {
         "node": ">= 14.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {
@@ -809,12 +771,8 @@ it('can bundle a simple project with additional exports', async () => {
       "engines": {
         "node": ">= 12.0.0"
       },
-      "main": "cjs/index.js",
-      "module": "esm/index.js",
+      "main": "esm/index.js",
       "typings": "typings/index.d.ts",
-      "typescript": {
-        "definition": "typings/index.d.ts"
-      },
       "type": "module",
       "exports": {
         ".": {


### PR DESCRIPTION
> [!IMPORTANT]
> All package.jsons are now required to have `"type": "module"`. However, we can remove this requirement and accept CJS projects too - but we never use CJS in our projects.

## "main" package.json field matches the location of "type" output

> The "type" field defines the module format that Node.js uses for all .js files that have that package.json file as their nearest parent.
>
> Files ending with .js are loaded as ES modules when the nearest parent package.json file contains a top-level field "type" with a value of "module".
>
> If the nearest parent package.json lacks a "type" field, or contains "type": "commonjs", .js files are treated as CommonJS. If the volume root is reached and no package.json is found, .js files are treated as CommonJS.

_[Node documentation](https://nodejs.org/api/packages.html#type)_

## Drop "module" package.json field

The field was just a proposal and Node never officially supported it. Node instead uses the ["exports" field](https://nodejs.org/api/packages.html#exports).

## Drop "typescript" package.json field

I don't know why this existed in the first place. If someone explains why we had it and the argument is still valid, we can put it back.